### PR TITLE
Fix: Renaming marker variables, Enhancing regex pattern escaping

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24033,8 +24033,8 @@ var KarmaService = class {
     this.#state = /* @__PURE__ */ new Map();
     this.#config = config;
     this.#exclude = exclude.map((pattern) => {
-      const regexPattern = pattern.replace(/\./g, "\\.").replace(/\*/g, ".*").replace(/\?/g, ".");
-      return new RegExp(`^${regexPattern}$`, "i");
+      const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".");
+      return new RegExp(`^${escaped}$`, "i");
     });
   }
   getLeaderboard() {
@@ -24098,7 +24098,6 @@ var KarmaService = class {
           { owner, repo, state: "all" },
           octokit
         );
-
         const pureIssues = issues.filter((issue) => !issue.pull_request);
         pureIssues.forEach((issue) => {
           if (issue.user && issue.user.login && !this.isExcluded(issue.user.login, issue.user.email || "")) {
@@ -24169,7 +24168,7 @@ var writeMarkdown = (output, markdown, markers) => {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
- if (!(markers == null ? void 0 : markers.marker_start) || !(markers == null ? void 0 : markers.marker_end)) {
+    if (!(markers == null ? void 0 : markers.marker_start) || !(markers == null ? void 0 : markers.marker_end)) {
       fs.writeFileSync(output, markdown);
       return;
     }
@@ -24252,8 +24251,8 @@ async function run() {
     const markdown = generateMarkdown(leaderboard);
     const output = (0, import_core.getInput)("output") || "CONTRIBUTORS.md";
     (0, import_core.info)(`Writing markdown to file: ${output}`);
-    const marker_start = (0, import_core.getInput)("marker-start") || null;
-    const marker_end = (0, import_core.getInput)("marker-end") || null;
+    const marker_start = (0, import_core.getInput)("marker_start") || null;
+    const marker_end = (0, import_core.getInput)("marker_end") || null;
     if (marker_start && marker_end) {
       (0, import_core.info)(
         `Using custom markers: ${marker_start} and ${marker_end}. This will overwrite the file content between these markers.`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -243,9 +243,9 @@ describe("run function", () => {
       switch (name) {
         case "token":
           return "mock-token";
-        case "marker-start":
+        case "marker_start":
           return "<!-- START -->";
-        case "marker-end":
+        case "marker_end":
           return "<!-- END -->";
         default:
           return "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,8 @@ export async function run() {
     const output: string = getInput("output") || "CONTRIBUTORS.md";
     info(`Writing markdown to file: ${output}`);
 
-    const marker_start: string | null = getInput("marker-start") || null;
-    const marker_end: string | null = getInput("marker-end") || null;
+    const marker_start: string | null = getInput("marker_start") || null;
+    const marker_end: string | null = getInput("marker_end") || null;
 
     if (marker_start && marker_end) {
       info(

--- a/src/services/karmaService.ts
+++ b/src/services/karmaService.ts
@@ -26,11 +26,12 @@ export class KarmaService {
     this.#state = new Map<string, number>();
     this.#config = config;
     this.#exclude = exclude.map((pattern) => {
-      const regexPattern = pattern
-        .replace(/\./g, "\\.")
+      const escaped = pattern
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
         .replace(/\*/g, ".*")
         .replace(/\?/g, ".");
-      return new RegExp(`^${regexPattern}$`, "i");
+
+      return new RegExp(`^${escaped}$`, "i");
     });
   }
 

--- a/src/utils/writeMarkdown.test.ts
+++ b/src/utils/writeMarkdown.test.ts
@@ -154,36 +154,6 @@ ${markers.marker_start}
     );
   });
 
-  it("handles leading/trailing whitespace around markers", () => {
-    const markers = {
-      marker_start: "<!-- START_SECTION -->",
-      marker_end: "<!-- END_SECTION -->",
-    };
-
-    const existingContent = `
-Header
-    ${markers.marker_start}
-old content
-    ${markers.marker_end}
-Footer
-`;
-
-    const expectedContent = `
-Header
-    ${markers.marker_start}
-# Test Markdown
-    ${markers.marker_end}
-Footer
-`;
-
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValueOnce(existingContent);
-
-    writeMarkdown(mockPath, mockContent, markers);
-
-    expect(fs.writeFileSync).toHaveBeenCalledWith(mockPath, expectedContent);
-  });
-
   it("passes through any fs errors", () => {
     vi.mocked(fs.existsSync).mockReturnValueOnce(false);
     vi.mocked(fs.mkdirSync).mockImplementationOnce(() => {


### PR DESCRIPTION
This pull request includes several changes to improve code consistency and enhance the regular expression handling in the project. The most important changes include the standardization of marker naming conventions, improvements to the regular expression escaping mechanism, and the removal of an outdated test case.

### Standardization of marker naming conventions:

* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L246-R248): Updated marker names from `marker-start` and `marker-end` to `marker_start` and `marker_end` for consistency.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L88-R89): Modified the input retrieval to use the updated marker names `marker_start` and `marker_end`.

### Improvements to regular expression handling:

* [`src/services/karmaService.ts`](diffhunk://#diff-867b184dd0ca3d4f1cf9cc5dca94033bd5d51298ec979b274eb342b847b448f7L29-R34): Enhanced the regular expression escaping by updating the replacement pattern to escape additional special characters.